### PR TITLE
fix(examples): fix title doesn't show when height is too small

### DIFF
--- a/packages/playground-nextjs/app/examples/page.tsx
+++ b/packages/playground-nextjs/app/examples/page.tsx
@@ -22,7 +22,7 @@ export default function Page({
   const showOutputBox = ex === 'events' || ex === 'all'
 
   return (
-    <main className="flex h-screen place-items-center justify-center p-4">
+    <main className="flex min-h-screen place-items-center justify-center p-4">
       <div className="max-w-7xl min-w-[800px]">
         <div className="text-center">
           <h1 className="text-xl font-bold tracking-tight sm:text-3xl">


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/c0563a98-5826-4e5c-b38c-96d6e5ba5bc8)

after:

![image](https://github.com/user-attachments/assets/35b1831a-1c8d-4440-a9ca-d48eecc6906e)
